### PR TITLE
Fix async file usage to avoid disposed stream

### DIFF
--- a/Services/UploadService.cs
+++ b/Services/UploadService.cs
@@ -46,6 +46,14 @@ namespace BalgImport.Services
 
             var fileName = Path.GetFileName(arquivo.FileName);
             var filePath = Path.Combine(_uploadPath, fileName);
+
+            // Copia o conteúdo do arquivo para memória enquanto o stream ainda está disponível
+            byte[] fileBytes;
+            using (var ms = new MemoryStream())
+            {
+                await arquivo.CopyToAsync(ms);
+                fileBytes = ms.ToArray();
+            }
             
             var upload = new StatusUpload
             {
@@ -67,15 +75,6 @@ namespace BalgImport.Services
                 try
                 {
                     upload.Status = "UPLOADING";
-                    
-                    // Lê o arquivo para um array de bytes de forma segura
-                    byte[] fileBytes;
-                    using (var ms = new MemoryStream())
-                    {
-                        // Copia o arquivo para o MemoryStream
-                        await arquivo.OpenReadStream().CopyToAsync(ms);
-                        fileBytes = ms.ToArray();
-                    }
 
                     // Salva o arquivo usando o semáforo
                     await _fileLock.WaitAsync();


### PR DESCRIPTION
## Summary
- copy uploaded file into memory before starting background task
- write the file from stored bytes to prevent `ObjectDisposedException`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685074a0c9e0832180f96d3247f69635